### PR TITLE
fix: Support RS256 verification and customized JWT for Tigris

### DIFF
--- a/api/helpers.go
+++ b/api/helpers.go
@@ -61,10 +61,10 @@ func getUserFromClaims(ctx context.Context, conn *storage.Connection) (*models.U
 	// System User
 	instanceID := getInstanceID(ctx)
 
-	if claims.Subject == models.SystemUserUUID.String() || claims.Subject == models.SystemUserID {
+	if GetUserIdFromSubject(claims.Subject) == models.SystemUserUUID.String() || GetUserIdFromSubject(claims.Subject) == models.SystemUserID {
 		return models.NewSystemUser(instanceID, claims.Audience), nil
 	}
-	userID, err := uuid.FromString(claims.Subject)
+	userID, err := uuid.FromString(GetUserIdFromSubject(claims.Subject))
 	if err != nil {
 		return nil, errors.New("Invalid user ID")
 	}

--- a/api/signup_test.go
+++ b/api/signup_test.go
@@ -93,7 +93,7 @@ func (ts *SignupTestSuite) TestWebhookTriggered() {
 			return []byte(ts.Config.Webhook.Secret), nil
 		})
 		assert.True(token.Valid)
-		assert.Equal(ts.instanceID.String(), claims.Subject) // not configured for multitenancy
+		assert.Equal(ts.instanceID.String(), GetUserIdFromSubject(claims.Subject)) // not configured for multitenancy
 		assert.Equal("gotrue", claims.Issuer)
 		assert.WithinDuration(time.Now(), time.Unix(claims.IssuedAt, 0), 5*time.Second)
 

--- a/api/token.go
+++ b/api/token.go
@@ -16,9 +16,9 @@ import (
 // GoTrueClaims is a struct thats used for JWT claims
 type GoTrueClaims struct {
 	jwt.StandardClaims
-	Email        string                 `json:"email"`
-	AppMetaData  map[string]interface{} `json:"https://tigris/n"`
-	UserMetaData map[string]interface{} `json:"user_metadata"`
+	TigrisMetadata map[string]interface{} `json:"https://tigris"`
+	AppMetaData    map[string]interface{} `json:"app_metadata"`
+	UserMetaData   map[string]interface{} `json:"user_metadata"`
 }
 
 // AccessTokenResponse represents an OAuth2 success response
@@ -165,15 +165,17 @@ func (a *API) RefreshTokenGrant(ctx context.Context, w http.ResponseWriter, r *h
 }
 
 func generateAccessToken(user *models.User, expiresIn time.Duration, config *conf.Configuration, tokenSigner *TokenSigner) (string, error) {
+	tigrisClaims := map[string]interface{}{
+		"n": user.AppMetaData["namespace"],
+		"p": "test-project",
+	}
 	claims := &GoTrueClaims{
 		StandardClaims: jwt.StandardClaims{
-			Subject:   user.ID.String(),
+			Subject:   "gt|" + user.ID.String(), // customize sub b
 			Audience:  user.Aud,
 			ExpiresAt: time.Now().Add(expiresIn).Unix(),
 		},
-		Email:        user.Email,
-		AppMetaData:  user.AppMetaData,
-		UserMetaData: user.UserMetaData,
+		TigrisMetadata: tigrisClaims,
 	}
 
 	switch config.JWT.Algorithm {

--- a/api/user.go
+++ b/api/user.go
@@ -3,10 +3,11 @@ package api
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 
+	"github.com/gobuffalo/uuid"
 	"github.com/netlify/gotrue/models"
 	"github.com/netlify/gotrue/storage"
-	"github.com/gobuffalo/uuid"
 )
 
 // UserUpdateParams parameters for updating a user
@@ -26,7 +27,7 @@ func (a *API) UserGet(w http.ResponseWriter, r *http.Request) error {
 		return badRequestError("Could not read claims")
 	}
 
-	userID, err := uuid.FromString(claims.Subject)
+	userID, err := uuid.FromString(GetUserIdFromSubject(claims.Subject))
 	if err != nil {
 		return badRequestError("Could not read User ID claim")
 	}
@@ -47,6 +48,10 @@ func (a *API) UserGet(w http.ResponseWriter, r *http.Request) error {
 	return sendJSON(w, http.StatusOK, user)
 }
 
+func GetUserIdFromSubject(subject string) string {
+	return strings.Replace(subject, "gt|", "", 1)
+}
+
 // UserUpdate updates fields on a user
 func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
@@ -61,7 +66,7 @@ func (a *API) UserUpdate(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	claims := getClaims(ctx)
-	userID, err := uuid.FromString(claims.Subject)
+	userID, err := uuid.FromString(GetUserIdFromSubject(claims.Subject))
 	if err != nil {
 		return badRequestError("Could not read User ID claim")
 	}


### PR DESCRIPTION
- Added verification support for RS256. (TODO: gotrue verification only supports current key)
- Updated JKWS endpoint to render past keys information.
- Updated the schema of Subject claim with prefix `gt|` (to namespace it with gotrue)
- Updated the shape of access token for Tigris.