### PR TITLE
Fix: Docker build missing migrations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,6 @@ RUN adduser -D -u 1000 netlify
 
 RUN apk add --no-cache ca-certificates
 COPY --from=build /go/src/github.com/netlify/gotrue/gotrue /usr/local/bin/gotrue
-COPY --from=build /go/src/github.com/netlify/gotrue/migrations /usr/local/etc/gotrue/migrations/
-
-ENV GOTRUE_DB_MIGRATIONS_PATH /usr/local/etc/gotrue/migrations
 
 USER netlify
 CMD ["gotrue"]


### PR DESCRIPTION
## Describe your changes
Removes `migrations` from the build as with Tigris the sql migration scripts are not applicable.

## How best to test these changes
In the source directory run:
```
docker build .
```

If the image builds saying `Successfully built 41c2387a2317` or similar, you should be good. 

## Issue ticket number and link
N/A
