### PR TITLE
fix: Ignore the superadmin user creation error

### DIFF
--- a/hack/create_user.sh
+++ b/hack/create_user.sh
@@ -2,7 +2,7 @@
 
 CREATE=${CREATE_SUPER_ADMIN_USER:false}
 if [ "${CREATE}" == "true" ]; then
-  gotrue admin --instance_id="$GOTRUE_INSTANCE_ID" --aud="$GOTRUE_SUPERADMIN_AUD" --superadmin=true createuser "$GOTRUE_SUPERADMIN_USERNAME" "$GOTRUE_SUPERADMIN_PASSWORD"
+  gotrue admin --instance_id="$GOTRUE_INSTANCE_ID" --aud="$GOTRUE_SUPERADMIN_AUD" --superadmin=true createuser "$GOTRUE_SUPERADMIN_USERNAME" "$GOTRUE_SUPERADMIN_PASSWORD" || true
 else
   echo "Skipped creation of user"
 fi


### PR DESCRIPTION
## Describe your changes
Superadmin user creation runs into error when user already exists. This is to suppress the error and let the gotrue startup in case of superadmin creation error.

## How best to test these changes

## Issue ticket number and link
