### PR TITLE
fix: List app keys filter by tigris project

### DIFF
--- a/api/admin.go
+++ b/api/admin.go
@@ -69,8 +69,9 @@ func (a *API) adminUsers(w http.ResponseWriter, r *http.Request) error {
 	filter := r.URL.Query().Get("filter")
 	namespaceFilter := r.URL.Query().Get("tigris_namespace")
 	createdByFilter := r.URL.Query().Get("created_by")
+	projectFilter := r.URL.Query().Get("tigris_project")
 
-	users, err := models.FindUsersInAudience(ctx, a.db, instanceID, aud, pageParams, sortParams, filter, namespaceFilter, createdByFilter, a.encrypter)
+	users, err := models.FindUsersInAudience(ctx, a.db, instanceID, aud, pageParams, sortParams, filter, namespaceFilter, createdByFilter, projectFilter, a.encrypter)
 	if err != nil {
 		return internalServerError("Database error finding users").WithInternalError(err)
 	}

--- a/models/user_test.go
+++ b/models/user_test.go
@@ -113,7 +113,7 @@ func (ts *UserTestSuite) TestFindUsersInAudience() {
 	u := ts.createUser()
 
 	ctx := context.TODO()
-	n, err := FindUsersInAudience(ctx, ts.db, u.InstanceID, u.Aud, nil, nil, "", "", "", ts.encrypter)
+	n, err := FindUsersInAudience(ctx, ts.db, u.InstanceID, u.Aud, nil, nil, "", "test", "", "test", ts.encrypter)
 	require.NoError(ts.T(), err)
 	require.Len(ts.T(), n, 1)
 
@@ -121,7 +121,7 @@ func (ts *UserTestSuite) TestFindUsersInAudience() {
 		Page:    1,
 		PerPage: 50,
 	}
-	n, err = FindUsersInAudience(ctx, ts.db, u.InstanceID, u.Aud, &p, nil, "", "", "", ts.encrypter)
+	n, err = FindUsersInAudience(ctx, ts.db, u.InstanceID, u.Aud, &p, nil, "", "", "", "", ts.encrypter)
 	require.NoError(ts.T(), err)
 	require.Len(ts.T(), n, 1)
 	//ToDo: pagination related
@@ -132,7 +132,7 @@ func (ts *UserTestSuite) TestFindUsersInAudience() {
 			SortField{Name: "created_at", Dir: Descending},
 		},
 	}
-	n, err = FindUsersInAudience(ctx, ts.db, u.InstanceID, u.Aud, nil, sp, "", "", "", ts.encrypter)
+	n, err = FindUsersInAudience(ctx, ts.db, u.InstanceID, u.Aud, nil, sp, "", "", "", "", ts.encrypter)
 	require.NoError(ts.T(), err)
 	require.Len(ts.T(), n, 1)
 }
@@ -206,7 +206,13 @@ func (ts *UserTestSuite) createUser() *User {
 }
 
 func (ts *UserTestSuite) createUserWithEmail(email string) *User {
-	user, err := NewUser(uuid.Nil, email, "secret", "test", nil, ts.encrypter)
+	user, err := NewUserWithAppData(uuid.Nil, email, "secret", "test", nil, UserAppMetadata{
+		Name:            "test",
+		Description:     "test",
+		Provider:        "email",
+		TigrisProject:   "test",
+		TigrisNamespace: "test",
+	}, ts.encrypter)
 	require.NoError(ts.T(), err)
 
 	_, err = tigris.GetCollection[User](ts.db).Insert(context.TODO(), user)


### PR DESCRIPTION
Appkeys are associated with Tigris project. Historically - app keys were not associated with Tigris project. This PR accepts a filter while listing app keys that takes a tigris project name. It filters the app key if the tigris project name is either empty or matches the value supplied.