### PR TITLE
Close the iterator after reading users

### DIFF
--- a/models/user.go
+++ b/models/user.go
@@ -434,6 +434,7 @@ func FindUsersInAudience(ctx context.Context, database *tigris.Database, instanc
 		return nil, errors.Wrap(err, "reading user failed")
 	}
 
+	defer it.Close()
 	qfilter = strings.ToLower(qfilter)
 	var users []*User
 	var user User


### PR DESCRIPTION
## Describe your changes
There is a slow memory leak. The closing of iterator was missed as part of list users call. This PR fixes it.

## How best to test these changes

## Issue ticket number and link
