### PR TITLE
Add GHA to push gotrue image to Quay.io

### DIFF
--- a/.github/workflows/build-push-gotrue.yml
+++ b/.github/workflows/build-push-gotrue.yml
@@ -1,0 +1,60 @@
+name: publish docker image - gotrue
+
+on:
+  pull_request:
+    paths:
+      - Dockerfile*
+      - .github/workflows/*.yml
+  push:
+    branches:
+      - main
+
+env:
+  QUAY_REPO: "quay.io/tigrisdata/gotrue"
+
+jobs:
+  build-image:
+    name: Build and Push image
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Quay.io
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USER }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
+      - name: Get short github SHA
+        id: var
+        shell: bash
+        run: |
+          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ${{ env.QUAY_REPO }}
+          tags: |
+            github-${{ steps.var.outputs.sha_short }}
+            latest
+
+      - name: Build and push Docker images
+        id: build-push-to-quay
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
## Describe your changes
Added a new Github action to be able to push image to our Quay.io repository.

## How best to test these changes
The GHA will run with the pull_request, but the image will be only pushed when the pr is merged.

