### PR TITLE
ci: Update test CI workflow to fix the release

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,7 @@
-on: [ push ]
-
 name: Test
+on:
+  push:
+  workflow_call:
 jobs:
   test:
     strategy:


### PR DESCRIPTION
Attempt to fix 

```
error parsing called workflow
".github/workflows/release.yaml"
-> "./.github/workflows/test.yaml" (source branch with sha:3e5fd0397a07f660da0ca19328b6b7b6532d2b2b)
: workflow is not reusable as it is missing a `on.workflow_call` trigger
```