### PR TITLE
feat: Cache tokens

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -69,6 +69,7 @@ type GlobalConfiguration struct {
 		Endpoint            string
 		RequestIDHeader     string `envconfig:"REQUEST_ID_HEADER"`
 		EnableDebugEndpoint bool   `envconfig:"ENABLE_DEBUG_ENDPOINT"`
+		TokenCacheSize      int    `envconfig:"TOKEN_CACHE_SIZE" default:"100"`
 	}
 	DB                DBConfiguration
 	External          ProviderConfiguration

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/golang-jwt/jwt/v4 v4.1.0
 	github.com/google/uuid v1.3.0
+	github.com/hashicorp/golang-lru v0.5.1
 	github.com/imdario/mergo v0.0.0-20160216103600-3e95a51e0639
 	github.com/joho/godotenv v1.3.0
 	github.com/kelseyhightower/envconfig v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -264,6 +264,7 @@ github.com/hashicorp/go-msgpack v0.5.5/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iP
 github.com/hashicorp/go-retryablehttp v0.5.3/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/raft v1.1.0/go.mod h1:4Ak7FSPnuvmb0GV6vgIAJ4vYT4bek9bb6Q+7HVbyzqM=


### PR DESCRIPTION
## Describe your changes
Tigris uses admin authentication for many of the administration operation (like listusers, update users etc...). Adding cache in token response to avoid computing token every time and to improve the performance. In case of key rotation - this cache will have to be cleared with the restart of service.

## How best to test these changes
Existing tests exercises the flow.

## Issue ticket number and link
