### PR TITLE
fix: Added more logs around auth failure for /token calls

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -70,6 +70,7 @@ type GlobalConfiguration struct {
 		RequestIDHeader     string `envconfig:"REQUEST_ID_HEADER"`
 		EnableDebugEndpoint bool   `envconfig:"ENABLE_DEBUG_ENDPOINT"`
 		TokenCacheSize      int    `envconfig:"TOKEN_CACHE_SIZE" default:"100"`
+		EnableTokenCache    bool   `envconfig:"ENABLE_TOKEN_CACHE" default:"false"`
 	}
 	DB                DBConfiguration
 	External          ProviderConfiguration


### PR DESCRIPTION
## Describe your changes

- Added more informative logs for authentication failure calls. 
- Put the cache behind config flag (default disabled).

## How best to test these changes
N/A

## Issue ticket number and link
