### PR TITLE
fix: Exclude + character from invitation code

### DIFF
--- a/api/helpers.go
+++ b/api/helpers.go
@@ -218,7 +218,7 @@ func SafeHTTPClient(client *http.Client, log zerolog.Logger) *http.Client {
 }
 
 var (
-	chars = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-+")
+	chars = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-")
 )
 
 func GenerateRandomString(prefix string, length int) string {


### PR DESCRIPTION
## Describe your changes
When the invitation code gets URL encoded in user's web browser's GET method. It converts `+` to `%2B` and verification fails. We can url decode or just avoid this character in code.

## How best to test these changes

## Issue ticket number and link
