### PR TITLE
fix: Do not update the code in case of resending invitation

### DIFF
--- a/api/Invitation.go
+++ b/api/Invitation.go
@@ -63,7 +63,6 @@ func (a *API) CreateInvitation(w http.ResponseWriter, r *http.Request) error {
 			// update existing invitation
 			existingInvitation.ExpirationTime = invitation.ExpirationTime
 			existingInvitation.Status = InvitationStatusPending
-			existingInvitation.Code = invitation.Code
 			_, err := tigris.GetCollection[models.Invitation](a.db).InsertOrReplace(ctx, existingInvitation)
 			if err != nil {
 				return err

--- a/api/admin_test.go
+++ b/api/admin_test.go
@@ -209,6 +209,44 @@ func (ts *AdminTestSuite) TestAdminUsers_SortAsc() {
 }
 
 // TestAdminUsers tests API /admin/users route
+func (ts *AdminTestSuite) TestAdminUsers_SortDesc() {
+	// enable test once sorting is implemented
+	ts.T().Skip()
+	u, err := models.NewUserWithAppData(ts.instanceID, "test1@example.com", "test", ts.Config.JWT.Aud, nil, models.UserAppMetadata{
+		TigrisNamespace: "test",
+		TigrisProject:   "test",
+		Name:            "test",
+		Description:     "test",
+		Provider:        "email",
+	}, ts.Encrypter)
+	require.NoError(ts.T(), err, "Error making new user")
+	// if the created_at times are the same, then the sort order is not guaranteed
+	time.Sleep(1 * time.Second)
+
+	_, err = tigris.GetCollection[models.User](ts.API.db).Insert(context.TODO(), u)
+	require.NoError(ts.T(), err, "Error creating user")
+
+	// Setup request
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/admin/users", nil)
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", ts.token))
+
+	ts.API.handler.ServeHTTP(w, req)
+	require.Equal(ts.T(), http.StatusOK, w.Code)
+
+	data := struct {
+		Users []*models.User `json:"users"`
+		Aud   string         `json:"aud"`
+	}{}
+	require.NoError(ts.T(), json.NewDecoder(w.Body).Decode(&data))
+
+	require.Len(ts.T(), data.Users, 2)
+	assert.Equal(ts.T(), "test1@example.com", data.Users[0].Email)
+	assert.Equal(ts.T(), "test@example.com", data.Users[1].Email)
+}
+
+// TestAdminUsers tests API /admin/users route
 func (ts *AdminTestSuite) TestAdminUsers_FilterEmail() {
 	u, err := models.NewUserWithAppData(ts.instanceID, "test1@example.com", "test", ts.Config.JWT.Aud, nil, models.UserAppMetadata{
 		TigrisNamespace: "test",

--- a/api/invitation_test.go
+++ b/api/invitation_test.go
@@ -88,7 +88,7 @@ func (ts *InvitationTestSuite) TestMultipleInvitationBySameUser() {
 	require.Equal(ts.T(), 1, len(invitations))
 	require.Equal(ts.T(), "a@test.com", invitations[0].Email)
 	code2 := invitations[0].Code
-	require.NotEqual(ts.T(), code1, code2)
+	require.Equal(ts.T(), code1, code2)
 
 	// send another invitation to same user by same user
 	_ = createInvitation(ts, "a@test.com", "editor", "TestMultipleInvitationBySameUser", "org_a_display_name", "google2|1", "org_a admin username", time.Now().UnixMilli()+86400*1000)
@@ -96,8 +96,8 @@ func (ts *InvitationTestSuite) TestMultipleInvitationBySameUser() {
 	require.Equal(ts.T(), 1, len(invitations))
 	require.Equal(ts.T(), "a@test.com", invitations[0].Email)
 	code3 := invitations[0].Code
-	require.NotEqual(ts.T(), code3, code2)
-	require.NotEqual(ts.T(), code3, code1)
+	require.Equal(ts.T(), code3, code2)
+	require.Equal(ts.T(), code3, code1)
 }
 
 // TestDeleteInvitation tests API /invitation route


### PR DESCRIPTION
## Describe your changes
Do not update the code in case of resending invitation.

## How best to test these changes
Modified test to cover this behavior.

## Issue ticket number and link
