### PR TITLE
fix: URL encode the email address and code in invitation URL

### DIFF
--- a/mailer/customerio.go
+++ b/mailer/customerio.go
@@ -3,6 +3,7 @@ package mailer
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/customerio/go-customerio"
 	"github.com/netlify/gotrue/conf"
@@ -25,7 +26,10 @@ func (m *CustomerIOMailer) InviteMail(user *models.User, referrerURL string) err
 }
 
 func (m *CustomerIOMailer) TigrisInviteMail(email string, invitedByName string, code string, invitedOrgCode string, invitedOrgName string, role string, expirationTime int64) error {
-	invitationURL := fmt.Sprintf("%s/invitation?code=%s&email=%s", m.Config.TigrisConsoleURL, code, email)
+	urlEncodedEmail := url.QueryEscape(email)
+	urlEncodedCode := url.QueryEscape(code)
+
+	invitationURL := fmt.Sprintf("%s/invitation?code=%s&email=%s", m.Config.TigrisConsoleURL, urlEncodedCode, urlEncodedEmail)
 	request := customerio.SendEmailRequest{
 		To:                     email,
 		TransactionalMessageID: m.templateId,


### PR DESCRIPTION
## Describe your changes
URL encode the email address and code in invitation URL

## How best to test these changes

## Issue ticket number and link
