### PR TITLE
feat: Implement API keys support for Tigris

### DIFF
--- a/api/admin.go
+++ b/api/admin.go
@@ -70,8 +70,9 @@ func (a *API) adminUsers(w http.ResponseWriter, r *http.Request) error {
 	namespaceFilter := r.URL.Query().Get("tigris_namespace")
 	createdByFilter := r.URL.Query().Get("created_by")
 	projectFilter := r.URL.Query().Get("tigris_project")
+	keyTypeFilter := r.URL.Query().Get("key_type")
 
-	users, err := models.FindUsersInAudience(ctx, a.db, instanceID, aud, pageParams, sortParams, filter, namespaceFilter, createdByFilter, projectFilter, a.encrypter)
+	users, err := models.FindUsersInAudience(ctx, a.db, instanceID, aud, pageParams, sortParams, filter, namespaceFilter, createdByFilter, projectFilter, keyTypeFilter, a.encrypter)
 	if err != nil {
 		return internalServerError("Database error finding users").WithInternalError(err)
 	}
@@ -86,7 +87,8 @@ func (a *API) adminUsers(w http.ResponseWriter, r *http.Request) error {
 // adminUserGet returns information about a single user
 func (a *API) adminUserGet(w http.ResponseWriter, r *http.Request) error {
 	user := getUser(r.Context())
-
+	// decrypt
+	user.EncryptedPassword = a.encrypter.Decrypt(user.EncryptedPassword, user.EncryptionIV)
 	return sendJSON(w, http.StatusOK, user)
 }
 

--- a/models/user_test.go
+++ b/models/user_test.go
@@ -6,11 +6,11 @@ import (
 	"context"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 	"github.com/tigrisdata/gotrue/conf"
 	"github.com/tigrisdata/gotrue/crypto"
 	"github.com/tigrisdata/gotrue/storage/test"
-	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
 	"github.com/tigrisdata/tigris-client-go/tigris"
 )
 
@@ -113,7 +113,7 @@ func (ts *UserTestSuite) TestFindUsersInAudience() {
 	u := ts.createUser()
 
 	ctx := context.TODO()
-	n, err := FindUsersInAudience(ctx, ts.db, u.InstanceID, u.Aud, nil, nil, "", "test", "", "test", ts.encrypter)
+	n, err := FindUsersInAudience(ctx, ts.db, u.InstanceID, u.Aud, nil, nil, "", "test", "", "test", "", ts.encrypter)
 	require.NoError(ts.T(), err)
 	require.Len(ts.T(), n, 1)
 
@@ -121,7 +121,7 @@ func (ts *UserTestSuite) TestFindUsersInAudience() {
 		Page:    1,
 		PerPage: 50,
 	}
-	n, err = FindUsersInAudience(ctx, ts.db, u.InstanceID, u.Aud, &p, nil, "", "", "", "test", ts.encrypter)
+	n, err = FindUsersInAudience(ctx, ts.db, u.InstanceID, u.Aud, &p, nil, "", "", "", "test", "", ts.encrypter)
 	require.NoError(ts.T(), err)
 	require.Len(ts.T(), n, 1)
 	//ToDo: pagination related
@@ -132,7 +132,7 @@ func (ts *UserTestSuite) TestFindUsersInAudience() {
 			SortField{Name: "created_at", Dir: Descending},
 		},
 	}
-	n, err = FindUsersInAudience(ctx, ts.db, u.InstanceID, u.Aud, nil, sp, "", "", "", "", ts.encrypter)
+	n, err = FindUsersInAudience(ctx, ts.db, u.InstanceID, u.Aud, nil, sp, "", "", "", "", "", ts.encrypter)
 	require.NoError(ts.T(), err)
 	require.Len(ts.T(), n, 0)
 }


### PR DESCRIPTION
## Describe your changes
Made changes to implement API keys on Tigris. Extending the appkey to two types 1) credentials 2) api_key by extending app_metadata. API key is a special user whose email is encoded with the api key. 

## How best to test these changes
The consumer tests it via Tigris's integration test.

## Issue ticket number and link
